### PR TITLE
Fix app: py2/3 consistency

### DIFF
--- a/pydoop/app/main.py
+++ b/pydoop/app/main.py
@@ -79,11 +79,9 @@ def main(argv=None):
             args.combine_fn = args.combiner_fn  # backwards compatibility
     except AttributeError:  # not the script app
         pass
-
-    if not hasattr(args, 'func'):
-        parser.print_usage()
-        sys.exit(0)
     try:
         args.func(args, unknown)
+    except AttributeError:
+        parser.error("too few arguments")
     except RuntimeError as e:
         sys.exit("ERROR - {}:  {}".format(type(e).__name__, e))


### PR DESCRIPTION
Changes crs4#285 to handle empty args in the same way as Python2.

```
# pydoop2
usage: pydoop2 [-h] [-V] {script,submit} ...
pydoop2: error: too few arguments
[root@29f122db6bfd test]# echo $?
2
# pydoop3
usage: pydoop3 [-h] [-V] {script,submit} ...
pydoop3: error: too few arguments
[root@29f122db6bfd test]# echo $?
2
```