### PR TITLE
External splits: use single property

### DIFF
--- a/.travis/run_checks
+++ b/.travis/run_checks
@@ -8,6 +8,7 @@ docker exec pydoop bash -c \
   "source /etc/profile && cd test && ${PYTHON} all_tests.py"
 docker exec pydoop bash -c \
   "source /etc/profile && cd test/avro && ${PYTHON} all_tests.py"
+docker exec pydoop bash -c "source /etc/profile && cd test/src && bash try.sh"
 docker exec -e PYTHON="${PYTHON}" -e DEBUG="${DEBUG:-}" pydoop bash -c \
   "source /etc/profile && cd examples && ./run_all"
 docker exec -e PYTHON="${PYTHON}" -e DEBUG="${DEBUG:-}" pydoop bash -c \

--- a/test/src/it/crs4/pydoop/mapreduce/pipes/TestPipesExternalSplits.java
+++ b/test/src/it/crs4/pydoop/mapreduce/pipes/TestPipesExternalSplits.java
@@ -62,7 +62,6 @@ public class TestPipesExternalSplits {
     final String uri = UUID.randomUUID().toString();
     FileSystem fs = FileSystem.get(conf);
     Path path = new Path(uri);
-    conf.setBoolean(PipesNonJavaInputFormat.EXTERNAL_SPLITS_ENABLED, true);
     conf.set(PipesNonJavaInputFormat.EXTERNAL_SPLITS_URI, uri);
 
     TaskAttemptContextImpl tcontext =


### PR DESCRIPTION
* Removes `EXTERNAL_SPLITS_ENABLED` (external splits are disabled when `EXTERNAL_SPLITS_URI` is not set).
* Adds the new test to the Travis checks.